### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/custom-action.yml
+++ b/.github/workflows/custom-action.yml
@@ -1,4 +1,6 @@
 on: [push]
+permissions:
+  contents: read
 
 jobs:
   my-job:


### PR DESCRIPTION
Potential fix for [https://github.com/FlightSchool-io/Github-Examples/security/code-scanning/1](https://github.com/FlightSchool-io/Github-Examples/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any write operations, the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. This avoids redundancy and ensures consistent permissions across all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
